### PR TITLE
main: Do not clone systemd repo

### DIFF
--- a/main.xml
+++ b/main.xml
@@ -28,7 +28,6 @@
   <project groups="minilayout" name="kinvolk/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/seismograph" path="src/third_party/seismograph" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/shim" path="src/third_party/shim" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/systemd" path="src/third_party/systemd" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/toolbox" path="src/third_party/toolbox" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/torcx" path="src/third_party/torcx" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="refs/heads/master" upstream="refs/heads/master"/>


### PR DESCRIPTION
We don't use CROS_WORKON for systemd any more, so it is not necessary
to clone this repo.

This should be a conclusion of https://github.com/kinvolk/coreos-overlay/pull/659

Test build succeeded: http://localhost:9091/job/os/job/manifest/1860/cldsv/