### PR TITLE
switch to flatcar-master branches and drop rkt

### DIFF
--- a/main.xml
+++ b/main.xml
@@ -8,30 +8,29 @@
   
   <project groups="minilayout" name="appc/acbuild" path="src/third_party/appc-acbuild" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="appc/spec" path="src/third_party/appc-spec" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/afterburn" path="src/third_party/afterburn" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/baselayout" path="src/third_party/baselayout" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/bootengine" path="src/third_party/bootengine" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/coreos-cloudinit" path="src/third_party/coreos-cloudinit" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="kinvolk/afterburn" path="src/third_party/afterburn" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/baselayout" path="src/third_party/baselayout" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/bootengine" path="src/third_party/bootengine" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/coreos-cloudinit" path="src/third_party/coreos-cloudinit" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
   <project groups="minilayout" name="kinvolk/coreos-overlay" path="src/third_party/coreos-overlay" revision="refs/heads/main" upstream="refs/heads/main"/>
   <project groups="minilayout" name="kinvolk/flatcar-dev-util" path="src/platform/dev" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/docker" path="src/third_party/docker" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/fero" path="src/third_party/fero" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/grub" path="src/third_party/grub" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/ignition" path="src/third_party/ignition" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/init" path="src/third_party/init" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/locksmith" path="src/third_party/locksmith" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/mantle" path="src/third_party/mantle" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="kinvolk/ignition" path="src/third_party/ignition" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/init" path="src/third_party/init" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/locksmith" path="src/third_party/locksmith" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/mantle" path="src/third_party/mantle" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
   <project groups="minilayout" name="kinvolk/mayday" path="src/third_party/mayday" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/nss-altfiles" path="src/third_party/nss-altfiles" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="kinvolk/portage-stable" path="src/third_party/portage-stable" revision="refs/heads/main" upstream="refs/heads/main"/>
   <project groups="minilayout" name="kinvolk/flatcar-scripts" path="src/scripts" revision="refs/heads/main" upstream="refs/heads/main"/>
   <project groups="minilayout" name="kinvolk/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/seismograph" path="src/third_party/seismograph" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="kinvolk/seismograph" path="src/third_party/seismograph" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
   <project groups="minilayout" name="kinvolk/shim" path="src/third_party/shim" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/toolbox" path="src/third_party/toolbox" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/torcx" path="src/third_party/torcx" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="kinvolk/toolbox" path="src/third_party/toolbox" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
+  <project groups="minilayout" name="kinvolk/torcx" path="src/third_party/torcx" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-master"/>
   <project groups="minilayout" name="kinvolk/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/update_engine" path="src/third_party/update_engine" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/updateservicectl" path="src/third_party/updateservicectl" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="rkt/rkt" path="src/third_party/rkt" revision="refs/heads/master" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="kinvolk/update_engine" path="src/third_party/update_engine" revision="refs/heads/flatcar-master" upstream="refs/heads/flatcar-mmaster"/>
+  <project groups="minilayout" name="kinvolk/updateservicectl" path="src/third_party/updateservicectl" revision="refs/heads/main" upstream="refs/heads/main"/>
 </manifest>


### PR DESCRIPTION
We are using the flatcar-master branch of the modified repos, and even
though we don't rely on cros_workon or the checkouts, its still nice to
have the *correct* source code available.

Rkt has been removed from our images so we can drop the checkout too.